### PR TITLE
Added /profile to Navbar using Text and not an Icon

### DIFF
--- a/frontend/src/components/Post/GlobalNavBar.jsx
+++ b/frontend/src/components/Post/GlobalNavBar.jsx
@@ -35,10 +35,17 @@ function GlobalNavBar(props) {
             <a href="/posts">
               <MdOutlineRssFeed />
             </a>
+            
+            <div style={{ paddingRight: "20px" }}></div>
+            <a href="/profile">
+              My posts
+            </a>
+
             <div style={{ paddingRight: "20px" }}></div>
             <a href="/createpost">
               <MdOutlinePostAdd />
             </a>
+
             <div style={{ paddingRight: "20px" }}></div>
           </IconContext.Provider>
           <button onClick={clearLocalStorage} className="logout-button">


### PR DESCRIPTION
The team is free to turn this into an Icon later on as a nice to have. At least we have the new page linked in.